### PR TITLE
Added OSCAddressMethod - Closes #15

### DIFF
--- a/Sources/OSCKit/OSCAddressMethod.swift
+++ b/Sources/OSCKit/OSCAddressMethod.swift
@@ -1,0 +1,38 @@
+//
+//  File.swift
+//  
+//
+//  Created by Sam Smallman on 12/05/2020.
+//
+
+import Foundation
+
+struct OSCAddressMethod: Hashable, Equatable {
+    
+    let addressPattern: String
+    let parts: [String]
+    let completion: (OSCMessage) -> ()
+    
+    init(with addressPattern: String, andCompletionHandler completion: @escaping (OSCMessage) -> ()) {
+        self.addressPattern = addressPattern
+        var addressParts = addressPattern.components(separatedBy: "/")
+        addressParts.removeFirst()
+        self.parts = addressParts
+        self.completion = completion
+    }
+    
+    static func == (lhs: SKCallback, rhs: SKCallback) -> Bool {
+        return lhs.addressPattern == rhs.addressPattern
+    }
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(addressPattern)
+    }
+    
+    // "/a/b/c/d/e" is equal to "/a/b/c/d/e" or "/a/b/c/d/*".
+    func matches(part: String, atIndex index: Int) -> Bool {
+        guard parts.indices.contains(index) else { return false }
+        return parts[index] == part || parts[index] == "*"
+    }
+
+}


### PR DESCRIPTION
OSCAddressMethod is a helper class allowing users of the API to establish an Address Space.

For example in the class that is delegating for the OSCServer and conforming to OSCPacketDestination:


```
var addressSpace: Set<OSCAddressMethod> = []

func addMethod(_ method: OSCAddressMethod) {
    addressSpace.insert(method)
}

func foo(_ message: OSCMessage) -> () {
    print(message.addressPattern)
}

func registerAddressSpace() {
    addMethod(OSCAddressMethod(with: "/a/b/*/d/*", andCompletionHandler: foo(_:)))
    addMethod(OSCAddressMethod(with: "/a/b/*/d/*/f", andCompletionHandler: foo(_:)))
    addMethod(OSCAddressMethod(with: "/a/b/*/d", andCompletionHandler: foo(_:)))
}

func take(message: OSCMessage) {
    let matchedAddresses = OSCAddressMethod.matches(for: message.addressPattern, inAddressSpace: addressSpace)
    if matchedAddresses.isEmpty {
        print("The message is not a method within the address space")
    } else {
        matchedAddresses.forEach({ $0.completion(message) })
    }
}
```